### PR TITLE
adding dependencies with pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ docs/_build/
 target/
 
 report/node_modules
+
+bin/
+include/
+local/
+pip-selfcheck.json

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,4 @@
+* git clone git@github.com:julioleitao/python-bugzilla-report-api.git
+* virtualen python-bugzilla-report-api
+* source bin/activate
+* pip install -r requirements.txt

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-* git clone git@github.com:julioleitao/python-bugzilla-report-api.git
+* git clone git@github.com:marquesarthur/python-bugzilla-report-api.git
 * virtualen python-bugzilla-report-api
 * source bin/activate
 * pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+appdirs==1.4.3
+decorator==4.0.11
+enum34==1.1.6
+functools32==3.2.3.post2
+ipython-genutils==0.2.0
+jsonschema==2.6.0
+jupyter-core==4.3.0
+nbformat==4.3.0
+packaging==16.8
+plotly==2.0.8
+pyparsing==2.2.0
+pytz==2017.2
+requests==2.13.0
+six==1.10.0
+traitlets==4.3.2


### PR DESCRIPTION
All dependencies it's installed with pip. For isolated enviroment, virtualenv it's encouraged, but not required.

To install then just type:

`sudo apt-get install virtualenv`

`sudo apt-get install pip`